### PR TITLE
Makefile changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,16 +4,16 @@ else
 	OPEN='see'
 endif
 
-all: open
+all: statutter.pdf
 
-test: compile
+test: all
 
-compile:
+statutter.pdf: main.tex
 	@ test -d logs || mkdir logs
 	@ pdflatex --jobname=statutter -halt-on-error main.tex >> logs/compile \
 	  && echo "Compiled report" || (cat logs/compile && fail)
 
-open: compile
+open: statutter.pdf
 	$(OPEN) statutter.pdf
 
 clean:
@@ -27,11 +27,11 @@ publish: clean gh-pages/index.html gh-pages/statutter.pdf
 	ghp-import gh-pages
 	git push origin gh-pages -f
 
-gh-pages/index.html:
+gh-pages/index.html: content.tex
 	echo "---\nlayout: default\n---" > gh-pages/index.html
 	pandoc -f latex -t html content.tex >> gh-pages/index.html
 
-gh-pages/statutter.pdf: compile
+gh-pages/statutter.pdf: statutter.pdf
 	cp statutter.pdf gh-pages/.
 
-.PHONY: compile open clean publish
+.PHONY: open clean publish

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ TEX = $(shell find . -name "*.tex")
 
 all: statutter.pdf
 
-test: all
+test: clean statutter.pdf
 
 statutter.pdf: $(TEX)
 	@ test -d logs || mkdir logs

--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,14 @@ else
 	OPEN='see'
 endif
 
+# Used to check if any of the tex files have been changed
+TEX = $(shell find . -name "*.tex")
+
 all: statutter.pdf
 
 test: all
 
-statutter.pdf: main.tex
+statutter.pdf: $(TEX)
 	@ test -d logs || mkdir logs
 	@ pdflatex --jobname=statutter -halt-on-error main.tex >> logs/compile \
 	  && echo "Compiled report" || (cat logs/compile && fail)


### PR DESCRIPTION
Sets all the .tex-files in the current directory as dependencies to the compile target, so that it'll only re-compile if one of them have changed. Also updates the dependencies of the gh-pages targets, so they too won't run if nothing has changed.

I also renamed the `compile` target to `statutter.pdf` and set `make all` to compile instead of opening. Can make it open too though if you disagree.