### PR TITLE
Fix #24

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@ test: clean all jekyll
 	@ test -d logs || mkdir logs
 	@ pdflatex -halt-on-error $<  >> logs/compile \
 	  && echo "Compiled $@" || (cat logs/compile && fail)
+	@ pdflatex -halt-on-error $< >> logs/compile2 \
+	  && echo "Compiled again $@" || (cat logs/compile2 && fail)
 
 $(ABAKUS).tex: $(ABAKUS)/*.tex
 	@touch $@


### PR DESCRIPTION
`make all` now compiles each LaTeX document twice,
ensuring that the ToC and whatever else that requires
double compilation is displayed in the pdf.