### PR TITLE
fond: Start counting from 0

### DIFF
--- a/gh-pages/main.sass
+++ b/gh-pages/main.sass
@@ -21,7 +21,6 @@ body
 a
   color: $text-color
 
-
 .header
   font-size: 3em
   line-height: 1.4em
@@ -37,9 +36,6 @@ a
   max-width: 800px
   width: 90%
   margin: 1em auto
-
-.fond
-  counter-increment: h1counter
 
 h1
   margin-top: 1em


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/3536982/13259415/8a764ece-da57-11e5-8776-8668f2a13cd4.png)

This should be paragraph zero, not one, as it was changed in 2015: https://abakus.no/uploads/common/renskrevetreferat.pdf (see point 3.1)

The [PDF](http://statutter.abakus.no/fond-statutter.pdf) does this correctly.