### PR TITLE
Enable lgtm.co

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,14 @@ opprinnelige intensjon må endringen behandles på generalforsamling. Endringer
 som ikke blir disputert i løpet av denne perioden trer i kraft to -2- uker
 etter offentliggjøringen.
 
+### Godkjenne endringer
+[lgtm.co](https://lgtm.co) brukes for å passe på at minst to personer godkjenner
+eventuelle endringsforslag (pull requests) før de merges. Kun personer listet
+i filen [MAINTAINERS](MAINTAINERS) har mulighet til å gjøre dette, i form av en
+"LGTM"-kommentar ("looks good to me"). For mer informasjon, se
+[LGTMs dokumentasjon](https://lgtm.co/docs/overview/#approvals:68f80267fa3a50980dbb745a782b8dca).
+
+
 ## Innsending av forslag til endringer
 
 Det er to måter å sende inn forslag på: pull-request og epost. Det beste er å

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,4 @@
+kristeine
+eirsyl
+essoen
+ekmartin


### PR DESCRIPTION
@relekang suggested that we start using https://lgtm.co, which makes sure that all pull requests are signed off by at least two maintainers before merging. This means that all pull requests needs at least two "LGTM" ("looks good to me") comments on them from people listed in the `MAINTAINERS`-file before they can be merged.