### PR TITLE
Redaksjonelle endringer 2016

### DIFF
--- a/abakus-statutter.tex
+++ b/abakus-statutter.tex
@@ -31,7 +31,7 @@
   \Large{Statutter} \\
   \vspace{0.4cm}
   \normalsize{Vedtatt for første gang på ekstraordinær generalforsamling 29. januar 1980 \\
-              Sist endret ved ordinær generalforsamling 5. mars 2015}
+              Sist endret ved ordinær generalforsamling 4. mars 2016}
 \end{center}
 
 \newpage

--- a/abakus-statutter/00-definisjoner.tex
+++ b/abakus-statutter/00-definisjoner.tex
@@ -4,15 +4,15 @@ Kandidat til valg eller forslag som ligger til grunn har flere stemmer enn de
 andre kandidatene/forslagene.
 
 \subsection{Alminnelig flertall}
-Kandidat til valg eller forslag som ligger til grunn har flere stemmer enn 50\%
+Kandidat til valg eller forslag som ligger til grunn har flere stemmer enn 50 \%
 av stemmene til de tilstedeværende stemmeberettigede.
 
 \subsection{Kvalifisert flertall}
 Kandidat til valg eller forslag som ligger til grunn har flere stemmer enn 2/3
 av stemmene til de tilstedeværende stemmeberettigede.
 
-\subsection{Absolutt 50\% flertall}
-Kandidat til valg eller forslag som ligger til grunn har flere stemmer enn 50\%
+\subsection{Absolutt 50 \% flertall}
+Kandidat til valg eller forslag som ligger til grunn har flere stemmer enn 50 \%
 av stemmene til de stemmeberettigede.
 
 \subsection{Absolutt 2/3 flertall}

--- a/abakus-statutter/08-generalforsamling.tex
+++ b/abakus-statutter/08-generalforsamling.tex
@@ -62,7 +62,7 @@ Under generalforsamling tillates ikke bruk av fullmakt ved stemmegivning.
 
 \subsection{Statuttendringer}
 \subsubsection{}
-Statuttendringer krever kvalfisert flertall ved en generalforsamling.
+Statuttendringer krever kvalifisert flertall ved en generalforsamling.
 
 \subsubsection{}
 Vedtatte statuttendringer trer i kraft i det generalforsamlingen heves.

--- a/abakus-statutter/08-generalforsamling.tex
+++ b/abakus-statutter/08-generalforsamling.tex
@@ -127,7 +127,7 @@ generalforsamling på våren.  Kassererne legger fram resultatet til foreningens
 godkjennelse på generalforsamlingen.
 
 \subsubsection{}
-På ordinær generalforsamling skal det sittende hovedstyret legge fram en
+På ordinær generalforsamling skal det sittende Hovedstyret legge fram en
 redegjørelse for foreningens aktiviteter siden siste ordinære
 generalforsamling.
 

--- a/abakus-statutter/08-generalforsamling.tex
+++ b/abakus-statutter/08-generalforsamling.tex
@@ -105,8 +105,8 @@ Hvis det til slutt ikke gjenstår noen kandidater kan generalforsamlingen
 foreslå nye kandidater til valg. Dersom ingen
 kandidat får flertallet av stemmene må Hovedstyret stille en eller flere ny(e)
 kandidater innen én -1- uke. Ekstraordinær generalforsamling skal finne sted
-senest to uker etter det underkjente valget. Merk at tidsfrister for ordinært
-kandidatvalg ikke gjelder i dette tilfellet.
+senest to uker etter det underkjente valget. Tidsfrister for ordinært
+kandidatvalg gjelder ikke i dette tilfellet.
 
 \subsubsection{}
 Kandidater som har stilt til valg som leder, nestleder eller økonomiansvarlig

--- a/abakus-statutter/08-generalforsamling.tex
+++ b/abakus-statutter/08-generalforsamling.tex
@@ -86,12 +86,15 @@ som ikke blir disputert i løpet av denne perioden trer i kraft to -2- uker
 etter offentliggjøringen.
 
 \subsubsection{}
+Generalforsamlingen kan ikke overstyre statuttene, med mindre det er annonsert på forhånd som beskrevet i §8.3.6.
+
+\subsubsection{}
 Dersom et av Abakus' medlemmer ønsker å overstyre en statutt under
 generalforsamlingen må dette ønsket være Hovedstyret i hende minst to -2- uker
 før generalforsamlingen. Ønsker om overstyring av en statutt under
 generalforsamlingen må på forhånd opplyses om i sakspapirene. Hver enkelt
 overstyring skal stemmes over under generalforsamlingen og må godkjennes ved
-kvalifisert flertall. Generalforsamlingen kan ellers ikke overstyre statuttene.
+kvalifisert flertall.
 
 \subsection{Valg av leder, nestleder og økonomiansvarlig}
 \subsubsection{}

--- a/abakus-statutter/09-organisasjon.tex
+++ b/abakus-statutter/09-organisasjon.tex
@@ -26,7 +26,7 @@ lederne for komiteene Arrkom, Bedkom, Fagkom, Koskom, LaBamba, PR, readme og Web
 Hverken leder, nestleder eller økonomiansvarlig kan sitte som leder i noen komité.
 
 \subsubsection{}
-Nestleder er leders stedfortreder i leders fravær med leders samtykke.
+Nestleder er, med leders samtykke, leders stedfortreder i leders fravær.
 
 \subsubsection{}
 Vedtak som fattes på Hovedstyrets møter krever absolutt 50\% flertall. I

--- a/abakus-statutter/09-organisasjon.tex
+++ b/abakus-statutter/09-organisasjon.tex
@@ -21,9 +21,9 @@ Hovedstyret er Abakus øverste organ etter generalforsamlingen og skal styre
 Abakus i henhold til statuttene.
 
 \subsubsection{}
-Foreningens Hovedstyre består av leder, nestleder og økonomiansvarlig og
+Foreningens Hovedstyre består av leder, nestleder, økonomiansvarlig og
 lederne for komiteene Arrkom, Bedkom, Fagkom, Koskom, LaBamba, PR, readme og Webkom.
-Leder, nestleder og økonomiansvarlig kan ikke sitte som leder i noen komité.
+Hverken leder, nestleder eller økonomiansvarlig kan sitte som leder i noen komité.
 
 \subsubsection{}
 Nestleder er leders stedfortreder i leders fravær med leders samtykke.

--- a/abakus-statutter/09-organisasjon.tex
+++ b/abakus-statutter/09-organisasjon.tex
@@ -80,4 +80,4 @@ opptak.
 
 \subsubsection{}
 Interessegrupper er økonomisk og administrativt underlagt backup. Medlemskap i
-interessegruppene skal være tilgjengelig for alle abakusmedlemmer.
+interessegruppene skal være tilgjengelig for alle Abakus-medlemmer.

--- a/abakus-statutter/09-organisasjon.tex
+++ b/abakus-statutter/09-organisasjon.tex
@@ -29,7 +29,7 @@ Hverken leder, nestleder eller økonomiansvarlig kan sitte som leder i noen komi
 Nestleder er, med leders samtykke, leders stedfortreder i leders fravær.
 
 \subsubsection{}
-Vedtak som fattes på Hovedstyrets møter krever absolutt 50\% flertall. I
+Vedtak som fattes på Hovedstyrets møter krever absolutt 50 \% flertall. I
 tilfelle stemmelikhet har foreningens leder dobbeltstemme.
 
 \subsubsection{}

--- a/fond-statutter/00-03-fond.tex
+++ b/fond-statutter/00-03-fond.tex
@@ -1,7 +1,7 @@
 \section{Definisjoner}
 
 \subsection{Alminnelig flertall}
-Kandidat til valg eller forslag som ligger til grunn har flere stemmer enn 50\%
+Kandidat til valg eller forslag som ligger til grunn har flere stemmer enn 50 \%
 av stemmene til de tilstedeværende stemmeberettigede.
 
 \subsection{Kvalifisert flertall}
@@ -12,9 +12,9 @@ av stemmene til de tilstedeværende stemmeberettigede.
 Fondets navn er «Abakus’ fond».
 
 \section{Fondets formål}
-Abakus’ fonds formål er å gi Abakus en økonomisk trygghet og sørge for at Abakus sitt 
-økonomiske overskudd fordeles rettferdig på nåværende og fremtidige medlemmer av 
+Abakus’ fonds formål er å gi Abakus en økonomisk trygghet og sørge for at Abakus sitt
+økonomiske overskudd fordeles rettferdig på nåværende og fremtidige medlemmer av
 Abakus.
 \section{Fondets plassering}
-Fondet er plassert på en egen høyrentekonto som disponeres av Abakus, og som er separert 
+Fondet er plassert på en egen høyrentekonto som disponeres av Abakus, og som er separert
 fra den daglige driften til Abakus.

--- a/fond-statutter/04-styret.tex
+++ b/fond-statutter/04-styret.tex
@@ -6,7 +6,7 @@ Abakus’ fond i henhold til Abakus’ fonds statutter.
 \subsection{Fondstyrets sammensetning}
 Fondets styre består av et æresmedlem, et ordensmedlem, en tidligere økonomiansvarlig fra
 Hovedstyret, et tidligere medlem av Hovedstyret, Abakus-medlem 1 og Abakus-medlem 2.
-Ingen av fondstyret medlemmer kan ha aktive verv i Hovedstyret. Abakus-medlem 1 og 2 skal
+Ingen av fondstyrets medlemmer kan ha aktive verv i Hovedstyret. Abakus-medlem 1 og 2 skal
 være medlemmer som ikke innehar tittelen æresmedlem.
 
 \subsection{Valg av fondstyre}

--- a/fond-statutter/04-styret.tex
+++ b/fond-statutter/04-styret.tex
@@ -5,8 +5,8 @@ Abakus’ fond i henhold til Abakus’ fonds statutter.
 
 \subsection{Fondstyrets sammensetning}
 Fondets styre består av et æresmedlem, et ordensmedlem, en tidligere økonomiansvarlig fra
-Hovedstyret, et tidligere medlem av Hovedstyret, abakusmedlem 1 og abakusmedlem 2.
-Ingen av fondstyret medlemmer kan ha aktive verv i Hovedstyret. Abakusmedlem 1 og 2 skal
+Hovedstyret, et tidligere medlem av Hovedstyret, Abakus-medlem 1 og Abakus-medlem 2.
+Ingen av fondstyret medlemmer kan ha aktive verv i Hovedstyret. Abakus-medlem 1 og 2 skal
 være medlemmer som ikke innehar tittelen æresmedlem.
 
 \subsection{Valg av fondstyre}
@@ -22,18 +22,18 @@ den aktuelle stillingen.
 \subsubsection{}
 Det er Abakus’ Hovedstyre sin oppgave å passe på at det er tilstrekkelig med kandidater til
 stillingene slik at fondstyrets sammensetning kan godkjennes. Hovedstyret skal arbeide for
-at en av de to Abakusmedlemmene i fondets styre ikke skal være nåværende eller tidligere
+at en av de to Abakus-medlemmene i fondets styre ikke skal være nåværende eller tidligere
 medlem av en komité i Abakus.
 
 \subsubsection{}
 Nytt fondstyre inntrer 1.mai
 
 I oddetallsår skal følgende styremedlemmer velges på nytt: Ordensmedlem, et tidligere
-Hovedstyremedlem og Abakusmedlem 1.
+Hovedstyremedlem og Abakus-medlem 1.
 
 I partallsår skal følgende styremedlemmer velges på nytt: Æresmedlem, en tidligere
-økonomiansvarlig i Hovedstyret og Abakusmedlem 2.
+økonomiansvarlig i Hovedstyret og Abakus-medlem 2.
 
-Valgte kandidater skal godkjennes av generalforsamlingen. Æresmedlemmer, Ordensmedlemmer, 
+Valgte kandidater skal godkjennes av generalforsamlingen. Æresmedlemmer, Ordensmedlemmer,
 tidligere Hovedstyremedlemmer og tidligere økonomiansvarlig i Hovedstyret kan
 stille til gjenvalg til fondstyret.

--- a/fond-statutter/04-styret.tex
+++ b/fond-statutter/04-styret.tex
@@ -1,17 +1,17 @@
-\section{Fondets styre}
-\subsection{Om fondstyret}
+\section{Fondstyret}
+\subsection{Om Fondstyret}
 Fondstyret er Abakus’ fonds øverste organ etter generalforsamlingen og styrer
 Abakus’ fond i henhold til Abakus’ fonds statutter.
 
 \subsection{Fondstyrets sammensetning}
-Fondets styre består av et æresmedlem, et ordensmedlem, en tidligere økonomiansvarlig fra
+Fondstyret består av et æresmedlem, et ordensmedlem, en tidligere økonomiansvarlig fra
 Hovedstyret, et tidligere medlem av Hovedstyret, Abakus-medlem 1 og Abakus-medlem 2.
-Ingen av fondstyrets medlemmer kan ha aktive verv i Hovedstyret. Abakus-medlem 1 og 2 skal
+Ingen av Fondstyrets medlemmer kan ha aktive verv i Hovedstyret. Abakus-medlem 1 og 2 skal
 være medlemmer som ikke innehar tittelen æresmedlem.
 
 \subsection{Valg av fondstyre}
 \subsubsection{}
-Fondets styre skal velges på generalforsamling. Søknad fra interesserte kandidater
+Fondstyret skal velges på generalforsamling. Søknad fra interesserte kandidater
 leveres hovedstyret to -2- uker før ordinær generalforsamling.
 
 \subsubsection{}
@@ -21,8 +21,8 @@ den aktuelle stillingen.
 
 \subsubsection{}
 Det er Abakus’ Hovedstyre sin oppgave å passe på at det er tilstrekkelig med kandidater til
-stillingene slik at fondstyrets sammensetning kan godkjennes. Hovedstyret skal arbeide for
-at ett av de to Abakus-medlemmene i fondets styre ikke skal være nåværende eller tidligere
+stillingene slik at Fondstyrets sammensetning kan godkjennes. Hovedstyret skal arbeide for
+at ett av de to Abakus-medlemmene i Fondstyret ikke skal være nåværende eller tidligere
 medlem av en komité i Abakus.
 
 \subsubsection{}
@@ -36,4 +36,4 @@ I partallsår skal følgende styremedlemmer velges på nytt: Æresmedlem, en tid
 
 Valgte kandidater skal godkjennes av generalforsamlingen. Æresmedlemmer, Ordensmedlemmer,
 tidligere Hovedstyremedlemmer og tidligere økonomiansvarlig i Hovedstyret kan
-stille til gjenvalg til fondstyret.
+stille til gjenvalg til Fondstyret.

--- a/fond-statutter/04-styret.tex
+++ b/fond-statutter/04-styret.tex
@@ -22,7 +22,7 @@ den aktuelle stillingen.
 \subsubsection{}
 Det er Abakus’ Hovedstyre sin oppgave å passe på at det er tilstrekkelig med kandidater til
 stillingene slik at fondstyrets sammensetning kan godkjennes. Hovedstyret skal arbeide for
-at en av de to Abakus-medlemmene i fondets styre ikke skal være nåværende eller tidligere
+at ett av de to Abakus-medlemmene i fondets styre ikke skal være nåværende eller tidligere
 medlem av en komité i Abakus.
 
 \subsubsection{}

--- a/fond-statutter/04-styret.tex
+++ b/fond-statutter/04-styret.tex
@@ -26,7 +26,7 @@ at ett av de to Abakus-medlemmene i fondets styre ikke skal være nåværende el
 medlem av en komité i Abakus.
 
 \subsubsection{}
-Nytt fondstyre inntrer 1.mai
+Nytt fondstyre inntrer 1. mai.
 
 I oddetallsår skal følgende styremedlemmer velges på nytt: Ordensmedlem, et tidligere
 Hovedstyremedlem og Abakus-medlem 1.

--- a/fond-statutter/05-inntekter.tex
+++ b/fond-statutter/05-inntekter.tex
@@ -1,4 +1,4 @@
 \section{Fondets inntekter}
-Fondet henter sine inntekter fra Abakus. Størrelsen
-på overføringen fastsettes av Abakus 
-sine statutter. 
+Fondet får sine inntekter fra Abakus. Størrelsen
+på overføringen fastsettes av Abakus
+sine statutter.

--- a/fond-statutter/07-soknader.tex
+++ b/fond-statutter/07-soknader.tex
@@ -1,15 +1,15 @@
 \section{Krav til godkjenning av søknader}
 \subsection{Om søknadenes størrelse og godkjenning}
-En søknad om fondets midler skal sendes til fondets styre. Søknaden skal være
+En søknad om fondets midler skal sendes til Fondstyret. Søknaden skal være
 på minst 10 000 kr. Hovedstyret kan videresende mottatte søknader til fondet,
 uavhengig av beløpets størrelse. Søknader på mindre enn 250 000 kr og 25 \% av
-fondets størrelse, kan behandles av fondstyret. En slik søknad godkjennes av
-fondstyret ved kvalifisert flertall. Søknader på
+fondets størrelse, kan behandles av Fondstyret. En slik søknad godkjennes av
+Fondstyret ved kvalifisert flertall. Søknader på
 større beløp enn dette skal behandles av fondets generalforsamling. Søknaden
 godkjennes av generalforsamlingen ved kvalifisert flertall.
 
 \subsection{Årlige beløpsbegrensninger}
-Det er ingen årlige begrensninger på hvor mange søknader fondstyret kan
+Det er ingen årlige begrensninger på hvor mange søknader Fondstyret kan
 godkjenne. Totalsummen av godkjente søknader kan hverken overstige 300 000 kr
 eller 30 \% av fondets størrelse i løpet av et kalenderår. Dersom det ønskes å
 bruke mer enn dette må det godkjennes av fondets generalforsamlingen ved
@@ -22,4 +22,4 @@ anledning til å søke om fondets midler.
 \subsection{Søknadens innhold}
 Søknaden skal inneholde hvem som søker, formålet med søknaden og antall kroner
 det søkes om. Søknaden skal være velbegrunnet og ha som hensikt om å komme
-flest mulige medlemmer av Abakus til gode. 
+flest mulige medlemmer av Abakus til gode.

--- a/fond-statutter/08-generalforsamling.tex
+++ b/fond-statutter/08-generalforsamling.tex
@@ -2,7 +2,7 @@
 
 \subsection{}
 Abakus’ fonds ordinære generalforsamling skal holdes samtidig med Abakus sin
-ordinære generalforsamling of er fondets høyeste organ. For Abakus’ fonds
+ordinære generalforsamling og er fondets høyeste organ. For Abakus’ fonds
 generalforsamling gjelder følgende av Abakus’ statutter: 8.1.2, 8.1.4, 8.1.6,
 8.1.8, 8.2.2, 8.2.3, 8.3.2, 8.5.4.
 
@@ -14,7 +14,7 @@ to -2- medlemmer av fondstyret, to -2- medlemmer av Abakus’ hovedstyre og tret
 \subsection{}
 På generalforsamlingen skal fondstyret redegjøre for fondets størrelse,
 godkjente søknader og andre saker som fondstyret mener er av Abakus’
-interesse. 
+interesse.
 
 \subsection{}
 Det skal kalles inn til ekstraordinær generalforsamling dersom styret i

--- a/fond-statutter/08-generalforsamling.tex
+++ b/fond-statutter/08-generalforsamling.tex
@@ -8,12 +8,12 @@ generalforsamling gjelder følgende av Abakus’ statutter: 8.1.2, 8.1.4, 8.1.6,
 
 \subsection{}
 For at en generalforsamling skal være beslutningsdyktig kreves det at minimum
-to -2- medlemmer av fondstyret, to -2- medlemmer av Abakus’ Hovedstyre og tretti
+to -2- medlemmer av Fondstyret, to -2- medlemmer av Abakus’ Hovedstyre og tretti
 -30- medlemmer av Abakus er tilstede.
 
 \subsection{}
-På generalforsamlingen skal fondstyret redegjøre for fondets størrelse,
-godkjente søknader og andre saker som fondstyret mener er av Abakus’
+På generalforsamlingen skal Fondstyret redegjøre for fondets størrelse,
+godkjente søknader og andre saker som Fondstyret mener er av Abakus’
 interesse.
 
 \subsection{}

--- a/fond-statutter/08-generalforsamling.tex
+++ b/fond-statutter/08-generalforsamling.tex
@@ -8,7 +8,7 @@ generalforsamling gjelder følgende av Abakus’ statutter: 8.1.2, 8.1.4, 8.1.6,
 
 \subsection{}
 For at en generalforsamling skal være beslutningsdyktig kreves det at minimum
-to -2- medlemmer av fondstyret, to -2- medlemmer av Abakus’ hovedstyre og tretti
+to -2- medlemmer av fondstyret, to -2- medlemmer av Abakus’ Hovedstyre og tretti
 -30- medlemmer av Abakus er tilstede.
 
 \subsection{}

--- a/fond-statutter/09-statutter.tex
+++ b/fond-statutter/09-statutter.tex
@@ -8,4 +8,4 @@ generalforsamling. Alle medlemmer av Abakus kan komme med endringsforslag.
 Vedtatte statuttendringer trer i kraft i det generalforsamlingen heves.
 
 \subsection{}
-Fondets styre og Hovedstyret i Abakus har til enhver tid myndighet til å endre oppsett, utforming og formuleringer samt rette skrivefeil i Abakus' fonds statutter så fremt disse ikke endrer innholdet og betydningen i de aktuelle statuttene. Eventuelle endringsforslag må offentliggjøres 2. april eller 1. oktober.
+Fondstyret og Hovedstyret i Abakus har til enhver tid myndighet til å endre oppsett, utforming og formuleringer samt rette skrivefeil i Abakus' fonds statutter så fremt disse ikke endrer innholdet og betydningen i de aktuelle statuttene. Eventuelle endringsforslag må offentliggjøres 2. april eller 1. oktober.

--- a/fond-statutter/09-statutter.tex
+++ b/fond-statutter/09-statutter.tex
@@ -8,4 +8,4 @@ generalforsamling. Alle medlemmer av Abakus kan komme med endringsforslag.
 Vedtatte statuttendringer trer i kraft i det generalforsamlingen heves.
 
 \subsection{}
-Fondets styre og Hovedstyret i Abakus har til enhver tid myndighet til å endre oppsett, utforming og formuleringer samt rette skrivefeil i Abakus sine fondsstatutter så fremt disse ikke endrer innholdet og betydningen i de aktuelle statuttene. Eventuelle endringsforslag må offentliggjøres 2. april eller 1. oktober.
+Fondets styre og Hovedstyret i Abakus har til enhver tid myndighet til å endre oppsett, utforming og formuleringer samt rette skrivefeil i Abakus' fonds statutter så fremt disse ikke endrer innholdet og betydningen i de aktuelle statuttene. Eventuelle endringsforslag må offentliggjøres 2. april eller 1. oktober.


### PR DESCRIPTION
Hovedstyrets foreslåtte redaksjonelle endringer i Abakus' og Abakus' fonds statutter.

Hovedstyret kan foreslå redaksjonelle endringer i statuttene i henhold til §8.3.4 i Abakus' statutter og §9.3 i Abakus' fonds statutter.

Hovedstyret må redegjøre for de endringer de har gjort ved å offentliggjøre disse på foreningens nettside 2. april. Dersom et medlem av Abakus gir skriftlig uttrykk til Hovedstyret innen to -2- uker om at en endring ikke ivaretar statuttens opprinnelige intensjon må endringen behandles på generalforsamling. Endringer som ikke blir disputert i løpet av denne perioden trer i kraft to -2- uker etter offentliggjøringen.