### PR TITLE
Redaksjonelle endringer, høst 2016

### DIFF
--- a/fond-statutter/04-styret.tex
+++ b/fond-statutter/04-styret.tex
@@ -5,9 +5,9 @@ Abakus’ fond i henhold til Abakus’ fonds statutter.
 
 \subsection{Fondstyrets sammensetning}
 Fondstyret består av et æresmedlem, et ordensmedlem, en tidligere økonomiansvarlig fra
-Hovedstyret, et tidligere medlem av Hovedstyret, Abakus-medlem 1 og Abakus-medlem 2.
-Ingen av Fondstyrets medlemmer kan ha aktive verv i Hovedstyret. Abakus-medlem 1 og 2 skal
-være medlemmer som ikke innehar tittelen æresmedlem.
+Hovedstyret, et tidligere medlem av Hovedstyret og to Abakus-medlemmer.
+Ingen av Fondstyrets medlemmer kan ha aktive verv i Hovedstyret. De to Abakus-medlemmene
+skal ikke være medlemmer som innehar tittelen æresmedlem.
 
 \subsection{Valg av fondstyre}
 \subsubsection{}
@@ -29,10 +29,12 @@ medlem av en komité i Abakus.
 Nytt fondstyre inntrer 1. mai.
 
 I oddetallsår skal følgende styremedlemmer velges på nytt: Ordensmedlem, et tidligere
-Hovedstyremedlem og Abakus-medlem 1.
+Hovedstyremedlem og et Abakus-medlem.
 
 I partallsår skal følgende styremedlemmer velges på nytt: Æresmedlem, en tidligere
-økonomiansvarlig i Hovedstyret og Abakus-medlem 2.
+økonomiansvarlig i Hovedstyret og et Abakus-medlem.
+
+Det er Abakus-medlemmet som har sittet i Fondstyret i to -2- år som erstattes.
 
 Valgte kandidater skal godkjennes av generalforsamlingen. Æresmedlemmer, Ordensmedlemmer,
 tidligere Hovedstyremedlemmer og tidligere økonomiansvarlig i Hovedstyret kan

--- a/fond-statutter/08-generalforsamling.tex
+++ b/fond-statutter/08-generalforsamling.tex
@@ -18,7 +18,7 @@ interesse.
 
 \subsection{}
 Det skal kalles inn til ekstraordinær generalforsamling dersom styret i
-Abakus’ fond eller minst 10 medlemmer av Abakus krever det.
+Abakus’ fond eller minst ti -10- medlemmer av Abakus krever det.
 
 \subsection{}
 Kun medlemmer av Abakus har stemmerett og oppmøterett på en generalforsamling.

--- a/fond-statutter/10-opplosning.tex
+++ b/fond-statutter/10-opplosning.tex
@@ -1,6 +1,6 @@
 \section{Oppløsning av fondet}
 En oppløsning av fondet kan kun skje dersom et enstemmig fondstyre og
 generalforsamlingen ved kvalifisert flertall stemmer for. Ved oppløsning skal
-fondet stå uberørt i tre år, dette for å oppfordre til gjenopptak av fondet.
-Dersom det går tre år etter oppløsningen uten at fondet blir gjenopptatt,
+fondet stå uberørt i tre -3- år, dette for å oppfordre til gjenopptak av fondet.
+Dersom det går tre -3- år etter oppløsningen uten at fondet blir gjenopptatt,
 tilfaller fondets midler Abakus' hovedstyre.


### PR DESCRIPTION
Hovedstyrets foreslåtte redaksjonelle endringer i Abakus' og Abakus' fonds statutter. Det foreligger kun forslag for endringer av fondets statutter denne høsten.

Hovedstyret kan foreslå redaksjonelle endringer i statuttene i henhold til §8.3.4 i Abakus' statutter og §9.3 i Abakus' fonds statutter.

Hovedstyret må redegjøre for de endringer de har gjort ved å offentliggjøre disse på foreningens nettside 2. april. Dersom et medlem av Abakus gir skriftlig uttrykk til Hovedstyret innen to -2- uker om at en endring ikke ivaretar statuttens opprinnelige intensjon må endringen behandles på generalforsamling. Endringer som ikke blir disputert i løpet av denne perioden trer i kraft to -2- uker etter offentliggjøringen.
