### PR TITLE
Redaksjonelle endringer, vår 2017

### DIFF
--- a/abakus-statutter/01-03-foreningen.tex
+++ b/abakus-statutter/01-03-foreningen.tex
@@ -10,8 +10,8 @@ bidra med sosiale aktiviteter.
 \section{Foreningens logo}
 
 \subsection{}
-Foreningens logo bestemmes av generalforsamlingen. Enhver endring av logoen
-skal derfor godkjennes av generalforsamlingen ved kvalifisert flertall.
+Foreningens logo bestemmes av Generalforsamlingen. Enhver endring av logoen
+skal derfor godkjennes av Generalforsamlingen ved kvalifisert flertall.
 
 \subsection{}
 Foreningens offisielle logo skal alltid benyttes på fane og diplomer.

--- a/abakus-statutter/04-06-medlemskap.tex
+++ b/abakus-statutter/04-06-medlemskap.tex
@@ -15,7 +15,7 @@ Hovedstyret kan, hvis spesielle grunner tilsier det, tillate andre å bli
 medlemmer. Dette gjelder primært de studenter ved andre fakulteter og linjer
 som har data- og kommunikasjonsteknologi som hovedfag.
 
-\section{Medlemskontigent}
+\section{Medlemskontingent}
 Abakus har ingen medlemskontingent.
 
 \section{Æresmedlemskap}

--- a/abakus-statutter/07-arrangementer.tex
+++ b/abakus-statutter/07-arrangementer.tex
@@ -25,5 +25,5 @@ Abakus skal årlig arrangere:
 \end{itemize}
 
 \subsection{}
-Abakus skal arrangere jubileum hvert femte år. Det skal årlig settes inn penger
+Abakus skal arrangere jubileum hvert femte år etter 1977. Det skal årlig settes inn penger
 på en egen jubileumskonto. Beløpet bestemmes av Hovedstyret.

--- a/abakus-statutter/08-generalforsamling.tex
+++ b/abakus-statutter/08-generalforsamling.tex
@@ -1,11 +1,11 @@
 \section{Generalforsamling}
 \subsection{Om generalforsamlingen, innkallinger og frister}
 \subsubsection{}
-Generalforsamlingen er Abakus sitt høyeste organ og skal holdes minst én
+Generalforsamlingen er Abakus sitt høyeste organ og skal avholdes minst én
 gang i året.
 
 \subsubsection{}
-Ordinær generalforsamling skal finne sted i første uka av mars, men kan
+Ordinær generalforsamling skal finne sted i den første uken av mars, men kan
 flyttes opp til to -2- uker hvis Hovedstyret ser dette som hensiktsmessig.
 
 \subsubsection{}
@@ -50,11 +50,11 @@ fra hver komité.
 Alle foreningens medlemmer er stemmeberettigede.
 
 \subsubsection{}
-Dersom ikke annet er nevnt i statuttene, avgjøres en avstemning av generalforsamlingen ved
+Dersom ikke annet er nevnt i statuttene, avgjøres en avstemning i Generalforsamlingen ved
 alminnelig flertall.
 
 \subsubsection{}
-Vedtak fattet av en generalforsamling kan bare annuleres av en generalforsamling.
+Vedtak fattet av en generalforsamling kan bare annulleres av en generalforsamling.
 
 \subsubsection{}
 Under generalforsamling tillates ikke bruk av fullmakt ved stemmegivning.
@@ -80,7 +80,7 @@ endringsforslag må offentliggjøres 2. april eller 1. oktober.
 Hovedstyret må redegjøre for de endringer de har gjort ved å offentliggjøre
 disse på foreningens nettside. Dersom et medlem av Abakus gir skriftlig uttrykk
 til Hovedstyret innen to -2- uker om at en endring ikke ivaretar statuttens
-opprinnelige intensjon må endringen behandles på generalforsamling. Endringer
+opprinnelige intensjon, må endringen behandles på generalforsamling. Endringer
 som ikke blir disputert i løpet av denne perioden trer i kraft to -2- uker
 etter offentliggjøringen.
 
@@ -107,7 +107,7 @@ Hvis det til slutt ikke gjenstår noen kandidater kan generalforsamlingen
 foreslå nye kandidater til valg. Dersom ingen
 kandidat får flertallet av stemmene må Hovedstyret stille en eller flere ny(e)
 kandidater innen én -1- uke. Ekstraordinær generalforsamling skal finne sted
-senest to uker etter det underkjente valget. Tidsfrister for ordinært
+senest to -2- uker etter det underkjente valget. Tidsfrister for ordinært
 kandidatvalg gjelder ikke i dette tilfellet.
 
 \subsubsection{}


### PR DESCRIPTION
Forslag til redaksjonelle endringer for våren 2017, i henhold til § 8.3.4:

> § 8.3.4: Hovedstyret har til enhver tid myndighet til å endre oppsett, utforming og formuleringer samt rette skrivefeil i Abakus sine statutter såfremt disse ikke endrer innholdet og betydningen i de aktuelle statuttene. Eventuelle endringsforslag må offentliggjøres 2. april eller 1. oktober. 

> Hovedstyret må redegjøre for de endringer de har gjort ved å offentliggjøre disse på foreningens nettside. Dersom et medlem av Abakus gir skriftlig uttrykk til Hovedstyret innen to -2- uker om at en endring ikke ivaretar statuttens opprinnelige intensjon må endringen behandles på generalforsamling. Endringer som ikke blir disputert i løpet av denne perioden trer i kraft to -2- uker etter offentliggjøringen.

Dersom endringene ikke disputeres, vil de tre i kraft 16. april.