### PR TITLE
Fix spacing in header

### DIFF
--- a/gh-pages/_layouts/abakus.html
+++ b/gh-pages/_layouts/abakus.html
@@ -6,7 +6,7 @@ title: Abakus' statutter
   <img src="/abakule.jpg" alt="Abakus Logo" /> Abakus' statutter<br/>
   <div class="subtitle">
     Vedtatt for første gang på ekstraordinær generalforsamling 29. januar 1980 <br/>
-    Sist endret ved ordinær generalforsamling 22. februar 2019<br/>
+    Sist endret ved ordinær generalforsamling 22. februar 2019 <br/>
     Dokumentet kan lastes ned <a class="download" href="/abakus-statutter.pdf">her</a>
   </div>
   <div class="subtitle links">


### PR DESCRIPTION
Should be the same in "fondet" and "abakus".


This fixes the annoying bug when switching between fondet and abakus on statutter.abakus.no