### PR TITLE
Define css counters on first element of body.

### DIFF
--- a/gh-pages/main.sass
+++ b/gh-pages/main.sass
@@ -18,8 +18,6 @@ body
   color: $text-color
   font-weight: 100
 
-  counter-reset: h1counter h2counter h3counter
-
 a
   color: $link-color
   text-decoration: none
@@ -62,6 +60,9 @@ p
 
 h1
   counter-reset: h2counter
+
+  &:first-child
+    counter-reset: h1counter h2counter h3counter
 
   &:not(:first-child)
     margin-top: 1.5em


### PR DESCRIPTION
This fixes the an issue where section counters never reset in firefox.

Chrome ignores the fact that a counte is defined at a level above, while
this is not the case for firefox. By defining the counters on the first
h1 element, all siblings have access to reset them, in contrary to
defining them on the body.

