### PR TITLE
Fix jekyll build in gh action deploy

### DIFF
--- a/.github/workflows/statutter.yml
+++ b/.github/workflows/statutter.yml
@@ -49,3 +49,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./gh-pages
+          enable_jekyll: true


### PR DESCRIPTION
- Move to github actions
- Fix incorrect path for artifact download in action
- Enable jekyll build for gh actions deploy
