### PR TITLE
Fix wrong section numbering for pdf

### DIFF
--- a/abakus-statutter.tex
+++ b/abakus-statutter.tex
@@ -22,6 +22,7 @@
      \renewcommand*\l@subsection{\@dottedtocline{1}{1.8em}{2.2em}}
 \makeatother
 
+\setcounter{section}{-1} % Start section count on zero
 \setcounter{tocdepth}{1}
 
 

--- a/abakus-statutter/definisjoner.tex
+++ b/abakus-statutter/definisjoner.tex
@@ -1,4 +1,3 @@
-\setcounter{section}{-1}
 \section{Definisjoner}
 \subsection{Simpelt flertall}
 Kandidat til valg eller forslag som ligger til grunn har flere stemmer enn de andre kandidatene/forslagene.


### PR DESCRIPTION
**before**
![image](https://github.com/abakus-ntnu/statutter/assets/66320400/f8c72ddc-1f13-4d3d-b84e-a110a9d704af)


**after**
![image](https://github.com/abakus-ntnu/statutter/assets/66320400/73f9a7e2-2b2b-4f7a-b8ea-1b1a7f8e374f)
