### PR TITLE
Editorial changes in 08-abakus-fond

### DIFF
--- a/abakus-statutter/08-abakus-fond.tex
+++ b/abakus-statutter/08-abakus-fond.tex
@@ -17,7 +17,7 @@ Ingen av Fondsstyrets medlemmer kan ha aktive verv i Hovedstyret eller være sit
 Valg til Fondsstyret gjennomføres på samme måte som valg til medlemmer av Hovedstyret (jf. \ref{subsec:genfors_valg}).
 
 \subsection{}
-En oppløsning av fondet kan kun skje dersom et enstemmig fondstyre og generalforsamlingen ved kvalifisert flertall 
+En oppløsning av fondet kan kun skje dersom et enstemmig Fondsstyret, og Generalforsamlingen ved kvalifisert flertall, 
 stemmer for. Ved oppløsning skal fondets investeringer selges, og stå uberørt på en høyrentekonto i \textbf{tre år}, dette for å
 oppfordre til gjenopptak av fondet. Dersom det går \textbf{tre år} etter oppløsningen uten at fondet blir gjenopptatt, 
 tilfaller fondets midler Hovedstyret.


### PR DESCRIPTION
Changed from "En oppløsning av fondet kan kun skje dersom et enstemmig fondstyre og generalforsamlingen ved kvalifisert flertall stemmer for. […]" to "En oppløsning av fondet kan kun skje dersom et enstemmig Fondsstyret, og Generalforsamlingen ved kvalifisert flertall, stemmer for. […]"