### PR TITLE
Editorial changes in 07-hovedstyret

### DIFF
--- a/abakus-statutter/07-hovedstyret.tex
+++ b/abakus-statutter/07-hovedstyret.tex
@@ -9,7 +9,7 @@ Hovedstyret er Abakus’ nest øverste organ og består av \textbf{seks} medlemm
     \item Økonomiansvarlig
     \item Tre øvrige styremedlemmer
 \end{enumerate}
-Hovedstyret har ansvar for å drifte foreningen forsvarlig, etter generalforsamlingens vedtak.
+Hovedstyret har ansvar for å drifte foreningen forsvarlig, etter Generalforsamlingens vedtak.
 \subsection{}
 Nestleder er leders stedfortreder i leders fravær. Leder og et annet styremedlem innehar signaturrett i fellesskap. 
 Alle medlemmer av Hovedstyret, samt komiteledere og revysjef, innehar individuelle prokura for sitt ansvarsområde. 


### PR DESCRIPTION
Changed from "generalforsamlingen" to "Generalforsamlingen"