### PR TITLE
Editorial changes in 06-generalforsamling

### DIFF
--- a/abakus-statutter/06-generalforsamling.tex
+++ b/abakus-statutter/06-generalforsamling.tex
@@ -77,4 +77,4 @@ flyttes opp til \textbf{to uker} hvis det sittende Hovedstyret ser dette som hen
 Hovedstyret skal legge frem referat fra generalforsamlingen.
 
 \subsubsection{}
-Bare generalforsamlingen kan opprette og nedlegge komiteer samt endre etiske retningslinjer.
+Bare Generalforsamlingen kan opprette og nedlegge komiteer samt endre etiske retningslinjer.


### PR DESCRIPTION
Changed from "generalforsamlingen" to "Generalforsamlingen"